### PR TITLE
Add trove classifiers specifying Python 3 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,9 @@ setup(name=PACKAGE,
         'console_scripts': [
             'jsonpointer = jsonpointer:main',
       ]},
+      classifiers=[
+        'Intended Audience :: Developers',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+      ],
 )


### PR DESCRIPTION
In _setup.py_, I added [trove classifiers](https://pypi.python.org/pypi?%3Aaction=list_classifiers) to clarify that the package supports Python 3. Besides PyPI, this information is used by [caniusepython3](https://github.com/brettcannon/caniusepython3) and sites like http://py3readiness.org to determine if a package is Py3 ready.

I was conservative with the classifiers and didn't, for example, add information about the license or development status, though this information would also be useful to include.
