### PR TITLE
More efficient resolving

### DIFF
--- a/jsonpointer.py
+++ b/jsonpointer.py
@@ -196,7 +196,12 @@ class JsonPointer(object):
     def get_part(self, doc, part):
         """ Returns the next step in the correct type """
 
-        if isinstance(doc, Sequence):
+        # Optimize for common cases of doc being a dict or list, but not a
+        # sub-class (because isinstance() is far slower)
+        ptype = type(doc)
+        if ptype == dict:
+            return part
+        if ptype == list or isinstance(doc, Sequence):
             if part == '-':
                 return part
             if not RE_ARRAY_INDEX.match(str(part)):

--- a/jsonpointer.py
+++ b/jsonpointer.py
@@ -196,27 +196,14 @@ class JsonPointer(object):
     def get_part(self, doc, part):
         """ Returns the next step in the correct type """
 
-        if isinstance(doc, Mapping):
-            return part
-
-        elif isinstance(doc, Sequence):
-
+        if isinstance(doc, Sequence):
             if part == '-':
                 return part
-
             if not RE_ARRAY_INDEX.match(str(part)):
                 raise JsonPointerException("'%s' is not a valid list index" % (part, ))
-
             return int(part)
-
-        elif hasattr(doc, '__getitem__'):
-            # Allow indexing via ducktyping if the target has defined __getitem__
-            return part
-
         else:
-            raise JsonPointerException("Document '%s' does not support indexing, "
-                                       "must be dict/list or support __getitem__" % type(doc))
-
+            return part
 
     def walk(self, doc, part):
         """ Walks one step in doc and returns the referenced part """
@@ -231,6 +218,10 @@ class JsonPointer(object):
             raise JsonPointerException("member '%s' not found in %s" % (part, doc))
         except IndexError:
             raise JsonPointerException("index '%s' is out of bounds" % (part, ))
+        except TypeError:
+            raise JsonPointerException("Document '%s' does not support indexing, "
+                                       "must be dict/list or support __getitem__" % type(doc))
+
 
     def contains(self, ptr):
         """Returns True if self contains the given ptr"""

--- a/jsonpointer.py
+++ b/jsonpointer.py
@@ -223,29 +223,14 @@ class JsonPointer(object):
 
         part = self.get_part(doc, part)
 
-        assert (type(doc) in (dict, list) or hasattr(doc, '__getitem__')), "invalid document type %s" % (type(doc),)
-
-        if isinstance(doc, Mapping):
-            try:
-                return doc[part]
-
-            except KeyError:
-                raise JsonPointerException("member '%s' not found in %s" % (part, doc))
-
-        elif isinstance(doc, Sequence):
-
-            if part == '-':
-                return EndOfList(doc)
-
-            try:
-                return doc[part]
-
-            except IndexError:
-                raise JsonPointerException("index '%s' is out of bounds" % (part, ))
-
-        else:
-            # Object supports __getitem__, assume custom indexing
+        if part == '-' and isinstance(doc, Sequence):
+            return EndOfList(doc)
+        try:
             return doc[part]
+        except KeyError:
+            raise JsonPointerException("member '%s' not found in %s" % (part, doc))
+        except IndexError:
+            raise JsonPointerException("index '%s' is out of bounds" % (part, ))
 
     def contains(self, ptr):
         """Returns True if self contains the given ptr"""


### PR DESCRIPTION
I was profiling some of my code which used `jsonpointer`, and I noticed that resolving pointers could be made faster.

My profiling script is at https://gist.github.com/alexsdutton/bb95e47a381d0e250fd3/988feaa0e8968893287df01c87eb233c9b86a010. Running on af04ec0, we get the following times on my laptop (Macbook Air, Fedora, Python 2.7.8):

```
3.43161201477 (/a/b/c/d/e/f)
8.24996113777 (/b/1/1/1/1/1)
7.04101395607 (/c/1/d/1/e/1/f)
1.00753712654 (/-)
```

After each commit we get, respectively:

```
2.40125393867
5.88285589218
4.9583530426
1.05458307266

3.08297109604
4.70882201195
4.62245106697
1.13339781761

1.59154200554
3.8058848381
3.40330195427
0.9848549366
```

So, about a 2x speed-up on the original code.
