### PR TITLE
Fix problem  creating rpm in python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ MODULES = (
         'jsonpointer',
 )
 
-AUTHOR_EMAIL = metadata['author']
+AUTHOR_EMAIL = metadata['author'].encode('utf8')
 VERSION = metadata['version']
 WEBSITE = metadata['website']
 LICENSE = metadata['license']


### PR DESCRIPTION
Running  python setup.py bdist_rpm in pythn2.7, I didnt test any other python versions.
```
warning: pypandoc module not found, could not convert Markdown to RST
running bdist_rpm
Traceback (most recent call last):
  File "setup.py", line 68, in <module>
    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
  File "/usr/lib64/python2.7/distutils/core.py", line 151, in setup
    dist.run_commands()
  File "/usr/lib64/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib64/python2.7/distutils/dist.py", line 971, in run_command
    cmd_obj.ensure_finalized()
  File "/usr/lib64/python2.7/distutils/cmd.py", line 109, in ensure_finalized
    self.finalize_options()
  File "/usr/lib64/python2.7/distutils/command/bdist_rpm.py", line 219, in finalize_options
    self.finalize_package_data()
  File "/usr/lib64/python2.7/distutils/command/bdist_rpm.py", line 227, in finalize_package_data
    self.distribution.get_contact_email()))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 8: ordinal not in range(128)

```