### PR TITLE
Add support for uri fragments

### DIFF
--- a/jsonpointer.py
+++ b/jsonpointer.py
@@ -53,6 +53,7 @@ except ImportError:  # Python 3
     from collections import Mapping, Sequence
 
 from itertools import tee
+from requests.utils import unquote
 import re
 import copy
 
@@ -178,10 +179,14 @@ class JsonPointer(object):
                 invalid_escape.group()))
 
         parts = pointer.split('/')
-        if parts.pop(0) != '':
-            raise JsonPointerException('Location must start with /')
+        first_part = parts.pop(0)
+        if first_part not in ('', '#'):
+            raise JsonPointerException('Location must start with / or #')
 
         parts = [unescape(part) for part in parts]
+        if first_part == '#':
+            parts = [unquote(part) for part in parts]
+
         self.parts = parts
 
     def to_last(self, doc):

--- a/tests.py
+++ b/tests.py
@@ -42,6 +42,34 @@ class SpecificationTests(unittest.TestCase):
         self.assertEqual(resolve_pointer(doc, "/m~0n"), 8)
 
 
+    def test_example_uri_fragment(self):
+        doc =   {
+            "foo": ["bar", "baz"],
+            "": 0,
+            "a/b": 1,
+            "c%d": 2,
+            "e^f": 3,
+            "g|h": 4,
+            "i\\j": 5,
+            "k\"l": 6,
+            " ": 7,
+            "m~n": 8
+        }
+
+        self.assertEqual(resolve_pointer(doc, "#"), doc)
+        self.assertEqual(resolve_pointer(doc, "#/foo"), ["bar", "baz"])
+        self.assertEqual(resolve_pointer(doc, "#/foo/0"), "bar")
+        self.assertEqual(resolve_pointer(doc, "#/"), 0)
+        self.assertEqual(resolve_pointer(doc, "#/a~1b"), 1)
+        self.assertEqual(resolve_pointer(doc, "#/c%25d"), 2)
+        self.assertEqual(resolve_pointer(doc, "#/e%5Ef"), 3)
+        self.assertEqual(resolve_pointer(doc, "#/g%7Ch"), 4)
+        self.assertEqual(resolve_pointer(doc, "#/i%5Cj"), 5)
+        self.assertEqual(resolve_pointer(doc, "#/k%22l"), 6)
+        self.assertEqual(resolve_pointer(doc, "#/%20"), 7)
+        self.assertEqual(resolve_pointer(doc, "#/m~0n"), 8)
+
+
     def test_eol(self):
         doc = {
             "foo": ["bar", "baz"]


### PR DESCRIPTION
Json pointers which start with '#' are currently not supported. This adds support for them. 

**Note**: I am adding a dependency on `requests`, but I am not sure if that comes with standard python now. 