### PR TITLE
Remove Travis CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ python-json-pointer
 
 [![PyPI version](https://img.shields.io/pypi/v/jsonpointer.svg)](https://pypi.python.org/pypi/jsonpointer/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/jsonpointer.svg)](https://pypi.python.org/pypi/jsonpointer/)
-[![Build Status](https://travis-ci.org/stefankoegl/python-json-pointer.svg?branch=master)](https://travis-ci.org/stefankoegl/python-json-pointer)
 [![Coverage Status](https://coveralls.io/repos/stefankoegl/python-json-pointer/badge.svg?branch=master)](https://coveralls.io/r/stefankoegl/python-json-pointer?branch=master)
 
 


### PR DESCRIPTION
https://app.travis-ci.com/github/stefankoegl/python-json-pointer says:

> We are unable to start your build at this time. You exceeded the number of users allowed for your plan. Please review your plan details and follow the steps to resolution.

And the last build was 10 months ago.

Further, there's no `.travis.yml` in this repo.